### PR TITLE
Revamp `ASTNode` and `StoreValue` setup

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -2,7 +2,7 @@
 
 The full manual for KeplerKV including syntax and command specifics.
 
-Last updated: 2024-08-17
+Last updated: 2024-09-06
 
 ## Contents
 
@@ -66,6 +66,13 @@ Multiple commands can be completed at once by separating them with semicolons:
 Commands are **case-insentive** and may have alternate syntax. This documentation denotes commands and their arguments as:
 ```
 {set of equivalent invocations} required-argument [optional-arguments]
+```
+
+Many commands allow for batching such that multiple of the same command can be invoked:
+```bash
+\get a b
+    a | ...
+    b | ...
 ```
 
 ### Identifiers
@@ -132,8 +139,6 @@ Load in a store state from a valid save file produced from [`SAVE`](#save), deno
 **`\stats`**
 
 Displays basic statistics about the current instance of KeplerKV, including the total number of keys by type, and the memory usage.
-
-> The memory usage may appear bloated, such as one integer being more than four bytes. This is due to the use of `std::variant` inside the program which allows for polymoprhism in the store's values, but introduces some overhead!
 
 ## Commands: Data
 

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -77,6 +77,9 @@ A NoSQL key-value pair store for quick access.
     - Strings and identifiers utilize the same string functionality. For now I am using a common `StringHandler` interface to share, but perhaps making `IdentifierValue` be a sublass of `StringValue` may simplify this?
 - New `evaluate()` functions for each `ASTNode` to create appropriate `StoreValue` type
     - More clear, forward conversion from the parser to actual values
+- Revamped `Parser` to not return anything related to `StoreValue`
+    - `Parser` only deals with the `ASTNode` representation of a value
+- Let `Identifier` abstractions (AST and Value) inherit from `String` since they are functionally the same and an enum is used to distinguish them during use
 
 ### September 5, 2024
 The current system using `std::variant` for the `StoreValue` and generic `ValueNode`s introduces a significant overhead within the program and bloated lines of code for type-checking and reducing the true type of a value.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -72,6 +72,11 @@ A NoSQL key-value pair store for quick access.
 
 ---
 ## dev journal
+### September 6, 2024
+- Reworked serialization and deserialization for individual `StoreValue` types
+    - Strings and identifiers utilize the same string functionality. For now I am using a common `StringHandler` interface to share, but perhaps making `IdentifierValue` be a sublass of `StringValue` may simplify this?
+- New `evaluate()` functions for each `ASTNode` to create appropriate `StoreValue` type
+    - More clear, forward conversion from the parser to actual values
 
 ### September 5, 2024
 The current system using `std::variant` for the `StoreValue` and generic `ValueNode`s introduces a significant overhead within the program and bloated lines of code for type-checking and reducing the true type of a value.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -16,7 +16,7 @@ A NoSQL key-value pair store for quick access.
         * [`class ASTNode`](/include/syntax_tree.h): represents a `Token`'s meaning and any contained data
     * Execution and validation done within `Handler`: may consider exporting this to a class if too unwiedly
 * [`class Store`](/include/store.h): in-memory representation of the store
-    * [`class StoreValue`](/include/store_value.h): variant type to hold different types of data
+    * [`class StoreValue`](/include/store_value.h): base class representing a value within the store, from which specific types inherit from, such as `IntValue`
 
 ### procedure for adding new commands
 1. Register a new value in the `CommandType` enum in [`syntax_tree.h`](/include/syntax_tree.h)
@@ -74,12 +74,13 @@ A NoSQL key-value pair store for quick access.
 ## dev journal
 ### September 6, 2024
 - Reworked serialization and deserialization for individual `StoreValue` types
-    - Strings and identifiers utilize the same string functionality. For now I am using a common `StringHandler` interface to share, but perhaps making `IdentifierValue` be a sublass of `StringValue` may simplify this?
+    - Strings and identifiers utilize the same string functionality: identifiers will now inherit from string classes (enums distinguish them)
 - New `evaluate()` functions for each `ASTNode` to create appropriate `StoreValue` type
     - More clear, forward conversion from the parser to actual values
 - Revamped `Parser` to not return anything related to `StoreValue`
     - `Parser` only deals with the `ASTNode` representation of a value
 - Let `Identifier` abstractions (AST and Value) inherit from `String` since they are functionally the same and an enum is used to distinguish them during use
+- Corresponding fixes to `Handler` and `Store` for the new scheme
 
 ### September 5, 2024
 The current system using `std::variant` for the `StoreValue` and generic `ValueNode`s introduces a significant overhead within the program and bloated lines of code for type-checking and reducing the true type of a value.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -73,6 +73,13 @@ A NoSQL key-value pair store for quick access.
 ---
 ## dev journal
 
+### September 5, 2024
+The current system using `std::variant` for the `StoreValue` and generic `ValueNode`s introduces a significant overhead within the program and bloated lines of code for type-checking and reducing the true type of a value.
+
+Adding more types and operations will only add onto this bloat, so I believe the next course of action would be implementing the type erasure paradigm and going back to more rigid type specifications.
+1. Make `ValueNode` a base class that specific types need to inherit from.
+2. Similarly, make `StoreValue` a base class.
+
 ### August 29, 2024
 - Implemented `SEARCH` that allows for searching by regex patterns
     - An $O(n)$ operation, oh dear

--- a/include/error_msgs.h
+++ b/include/error_msgs.h
@@ -1,10 +1,13 @@
 #pragma once
 #include <stdexcept>
 
+using Exception = std::exception;
 using RuntimeErr = std::runtime_error;
 
 #define UNEXPECTED      "Error: something went wrong, try again?"
-#define WRONG_FMT       "Error: incorrect command format"
+#define WRONG_CMD_FMT   "Error: incorrect command format"
+#define WRONG_F_FMT     "Error: incorrect float format"
+#define WRONG_I_FMT     "Error: incorrect integer format"
 #define NOT_IDENT       "Error: expected identifier"
 #define NOT_FOUND       "Error: not found in store"
 #define NOT_NUMERIC     "Error: not numeric (integer or float)"

--- a/include/error_msgs.h
+++ b/include/error_msgs.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <stdexcept>
 
 using Exception = std::exception;
@@ -9,12 +10,10 @@ using RuntimeErr = std::runtime_error;
 #define WRONG_F_FMT     "Error: incorrect float format"
 #define WRONG_I_FMT     "Error: incorrect integer format"
 #define NOT_IDENT       "Error: expected identifier"
-#define NOT_FOUND       "Error: not found in store"
 #define NOT_NUMERIC     "Error: not numeric (integer or float)"
 #define NOT_LIST        "Error: not a list"
 #define VAL_AFTER_IDENT "Error: expected value after identifier"
 #define CIRCULAR_REF    "Error: circular reference detected"
-#define SV_WRONG_TYPE   "Error: wrong type getter used with this value"
 #define NESTED_CMD      "Error: nested commands not supported (yet?)"
 #define CMD_IN_LIST     "Error: commands not supported within lists"
 #define FAIL_OPEN_WRITE "Error: failed to open file to write"
@@ -36,7 +35,7 @@ inline RuntimeErr MIN_TWO_ARG_KK(const std::string &c) {
 }
 
 inline RuntimeErr INVALID_CMD(const std::string &c) {
-    return RuntimeErr("Error: invalid command \'" + c + "\' (did you forget an '\'?)");
+    return RuntimeErr("Error: invalid command \'" + c + "\' (did you forget a quote or slsah?)");
 }
 
 inline RuntimeErr UNKNOWN_TOKEN(const std::string &t) {

--- a/include/error_msgs.h
+++ b/include/error_msgs.h
@@ -11,6 +11,7 @@ using RuntimeErr = std::runtime_error;
 #define NOT_IDENT       "Error: expected identifier"
 #define NOT_FOUND       "Error: not found in store"
 #define NOT_NUMERIC     "Error: not numeric (integer or float)"
+#define NOT_LIST        "Error: not a list"
 #define VAL_AFTER_IDENT "Error: expected value after identifier"
 #define CIRCULAR_REF    "Error: circular reference detected"
 #define SV_WRONG_TYPE   "Error: wrong type getter used with this value"

--- a/include/handler.h
+++ b/include/handler.h
@@ -9,15 +9,14 @@
 
 class Handler;
 using HandlerFunctionPtr
-    = std::function<void(Handler *, std::vector<ValueNodeSP> &, const std::size_t)>;
+    = std::function<void(Handler *, std::vector<ValueASTNodeSP> &, const std::size_t)>;
 
 class Handler {
 public:
-    Handler() {
-        lexer_ = Lexer();
-        parser_ = Parser();
-        store_ = Store();
-    };
+    Handler()
+        : lexer_(Lexer())
+        , parser_(Parser())
+        , store_(Store()) {};
 
     Handler(Lexer &l, Parser &p, Store &s)
         : lexer_(l)
@@ -25,10 +24,9 @@ public:
         , store_(s) {};
 
     Handler(Store &s)
-        : store_(s) {
-        lexer_ = Lexer();
-        parser_ = Parser();
-    };
+        : store_(s)
+        , lexer_(Lexer())
+        , parser_(Parser()) {};
 
     bool handleQuery(std::string &);
 
@@ -41,21 +39,21 @@ private:
 
     void print_item_(const std::string &, StoreValueSP);
 
-    std::string &getFilename_(ValueNodeSP);
+    std::string &getFilename_(ValueASTNodeSP);
 
     void handleStats_();
 
-    void handleSet_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handleGet_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handleDelete_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handleUpdate_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handleResolve_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handleSave_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handleLoad_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handleRename_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handleIncr_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handleDecr_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handleAppend_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handlePrepend_(std::vector<ValueNodeSP> &, const std::size_t);
-    void handleSearch_(std::vector<ValueNodeSP> &, const std::size_t);
+    void handleSet_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handleGet_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handleDelete_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handleUpdate_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handleResolve_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handleSave_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handleLoad_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handleRename_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handleIncr_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handleDecr_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handleAppend_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handlePrepend_(std::vector<ValueASTNodeSP> &, const std::size_t);
+    void handleSearch_(std::vector<ValueASTNodeSP> &, const std::size_t);
 };

--- a/include/handler.h
+++ b/include/handler.h
@@ -39,7 +39,7 @@ private:
 
     void print_item_(const std::string &, StoreValueSP);
 
-    std::string &getFilename_(ValueASTNodeSP);
+    std::string getFilename_(ValueASTNodeSP);
 
     void handleStats_();
 

--- a/include/handler.h
+++ b/include/handler.h
@@ -24,9 +24,9 @@ public:
         , store_(s) {};
 
     Handler(Store &s)
-        : store_(s)
-        , lexer_(Lexer())
-        , parser_(Parser()) {};
+        : lexer_(Lexer())
+        , parser_(Parser())
+        , store_(s) {};
 
     bool handleQuery(std::string &);
 

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -9,7 +9,8 @@ class Lexer {
 public:
     std::vector<TokenSP> tokens;
 
-    Lexer() { tokens = std::vector<TokenSP>(); };
+    Lexer()
+        : tokens(std::vector<TokenSP>()) {};
 
     std::vector<TokenSP> &tokenize(std::string &);
 

--- a/include/parser.h
+++ b/include/parser.h
@@ -7,7 +7,8 @@ class Parser {
 public:
     std::vector<ASTNodeSP> nodes;
 
-    Parser() { nodes = std::vector<ASTNodeSP>(); };
+    Parser()
+        : nodes(std::vector<ASTNodeSP>()) {};
 
     std::vector<ASTNodeSP> &parse(std::vector<TokenSP> &);
 

--- a/include/parser.h
+++ b/include/parser.h
@@ -16,7 +16,7 @@ private:
     std::vector<TokenSP>::iterator tt_;
     std::vector<TokenSP>::iterator tend_;
 
-    CommandNodeSP parseCommand_(TokenSP &);
+    CommandASTNodeSP parseCommand_(TokenSP &);
     ValueASTNodeSP parseValue_(TokenSP &);
     ValueASTNodeSP parseList_();
 };

--- a/include/parser.h
+++ b/include/parser.h
@@ -16,7 +16,7 @@ private:
     std::vector<TokenSP>::iterator tt_;
     std::vector<TokenSP>::iterator tend_;
 
-    ASTNodeSP parseCommand_(TokenSP &);
-    StoreValueSP parseValue_(TokenSP &);
-    StoreValueSP parseList_();
+    CommandNodeSP parseCommand_(TokenSP &);
+    ValueASTNodeSP parseValue_(TokenSP &);
+    ValueASTNodeSP parseList_();
 };

--- a/include/store_value.h
+++ b/include/store_value.h
@@ -77,7 +77,7 @@ private:
     float value_;
 };
 
-class StringValue : public StoreValue, public StringHandler {
+class StringValue : public StoreValue {
 public:
     StringValue(std::string s)
         : value_(s) {};
@@ -91,26 +91,19 @@ public:
     std::size_t size() const override { return sizeof(value_); }
     std::string string() const override { return "str: " + value_; }
 
-private:
+protected:
     std::string value_;
 };
 
-class IdentifierValue : public StoreValue, public StringHandler {
+class IdentifierValue : public StringValue {
 public:
     IdentifierValue(std::string s)
-        : value_(s) {};
-
-    std::string getValue() { return value_; }
+        : StringValue(s) {};
 
     std::vector<uint8_t> serialize() const override;
-    void deserialize(std::ifstream &) override;
 
     ValueType getValueType() const override { return ValueType::IDENTIIFER; }
-    std::size_t size() const override { return sizeof(value_); }
     std::string string() const override { return "id:" + value_; }
-
-private:
-    std::string value_;
 };
 
 class ListValue : public StoreValue {

--- a/include/store_value.h
+++ b/include/store_value.h
@@ -45,6 +45,8 @@ using NumberValueTypeSP = std::shared_ptr<NumberValueType>;
 
 class IntValue : public StoreValue, public NumberValueType {
 public:
+    IntValue()
+        : value_(0) {};
     IntValue(int i)
         : value_(i) {};
 
@@ -66,6 +68,8 @@ private:
 
 class FloatValue : public StoreValue, public NumberValueType {
 public:
+    FloatValue()
+        : value_(0) {};
     FloatValue(float f)
         : value_(f) {};
 
@@ -87,6 +91,8 @@ private:
 
 class StringValue : public StoreValue {
 public:
+    StringValue()
+        : value_("") {};
     StringValue(std::string s)
         : value_(s) {};
 
@@ -105,6 +111,8 @@ protected:
 
 class IdentifierValue : public StringValue {
 public:
+    IdentifierValue()
+        : StringValue() {};
     IdentifierValue(std::string s)
         : StringValue(s) {};
 

--- a/include/store_value.h
+++ b/include/store_value.h
@@ -35,15 +35,13 @@ public:
     };
 };
 
-class NumberValueType {
+class NumericType {
 public:
     virtual void incr() = 0;
     virtual void decr() = 0;
 };
 
-using NumberValueTypeSP = std::shared_ptr<NumberValueType>;
-
-class IntValue : public StoreValue, public NumberValueType {
+class IntValue : public StoreValue, public NumericType {
 public:
     IntValue()
         : value_(0) {};
@@ -66,7 +64,7 @@ private:
     int value_;
 };
 
-class FloatValue : public StoreValue, public NumberValueType {
+class FloatValue : public StoreValue, public NumericType {
 public:
     FloatValue()
         : value_(0) {};
@@ -119,7 +117,7 @@ public:
     std::vector<uint8_t> serialize() const override;
 
     ValueType getValueType() const override { return ValueType::IDENTIIFER; }
-    std::string string() const override { return "id:" + value_; }
+    std::string string() const override { return "id: " + value_; }
 };
 
 class ListValue : public StoreValue {
@@ -147,6 +145,7 @@ private:
     std::vector<StoreValueSP> value_;
 };
 
+using NumericTypeSP = std::shared_ptr<NumericType>;
 using IntValueSP = std::shared_ptr<IntValue>;
 using FloatValueSP = std::shared_ptr<FloatValue>;
 using StringValueSP = std::shared_ptr<StringValue>;

--- a/include/store_value.h
+++ b/include/store_value.h
@@ -130,3 +130,9 @@ public:
 private:
     std::vector<StoreValueSP> value_;
 };
+
+using IntValueSP = std::shared_ptr<IntValue>;
+using FloatValueSP = std::shared_ptr<FloatValue>;
+using StringValueSP = std::shared_ptr<StringValue>;
+using IdentifierValueSP = std::shared_ptr<IdentifierValue>;
+using ListValueSP = std::shared_ptr<ListValue>;

--- a/include/store_value.h
+++ b/include/store_value.h
@@ -14,8 +14,13 @@ class StoreValue {
 public:
     virtual ~StoreValue() = default;
 
-    virtual void serialize(std::ofstream &fp);
+    /* Values are serialized by type identiifer, size of the value, then raw data.
+    * ex. a string "abc" may be stored as s|4|abc
+    */
+    virtual std::vector<uint8_t> serialize() const;
     virtual void deserialize(std::ifstream &fp);
+
+    void toFile(std::ofstream &) const;
 
     virtual ValueType getValueType() const = 0;
     virtual std::size_t size() const = 0;
@@ -35,6 +40,8 @@ public:
 
     int getValue() { return value_; }
 
+    std::vector<uint8_t> serialize() const override;
+
     ValueType getValueType() { return ValueType::INT; }
     std::size_t size() const override { return sizeof(value_); }
     std::string string() const override { return "int: " + std::to_string(value_); }
@@ -52,6 +59,8 @@ public:
         : value_(f) {};
 
     float getValue() { return value_; }
+
+    std::vector<uint8_t> serialize() const override;
 
     ValueType getValueType() { return ValueType::FLOAT; }
     std::size_t size() const override { return sizeof(value_); }
@@ -71,6 +80,8 @@ public:
 
     std::string &getValue() { return value_; }
 
+    std::vector<uint8_t> serialize() const override;
+
     ValueType getValueType() { return ValueType::STRING; }
     std::size_t size() const override { return sizeof(value_); }
     std::string string() const override { return "str: " + value_; }
@@ -86,6 +97,8 @@ public:
 
     std::string getValue() { return value_; }
 
+    std::vector<uint8_t> serialize() const override;
+
     ValueType getValueType() { return ValueType::IDENTIIFER; }
     std::size_t size() const override { return sizeof(value_); }
     std::string string() const override { return "id:" + value_; }
@@ -100,8 +113,12 @@ public:
         : value_(std::vector<StoreValueSP>()) {};
     ListValue(std::vector<StoreValueSP> &l)
         : value_(l) {};
+    ListValue(std::vector<StoreValueSP> &&l)
+        : value_(std::move(l)) {};
 
     std::vector<StoreValueSP> &getValue() { return value_; }
+
+    std::vector<uint8_t> serialize() const override;
 
     ValueType getValueType() { return ValueType::LIST; }
     std::size_t size() const override;

--- a/include/store_value.h
+++ b/include/store_value.h
@@ -35,7 +35,15 @@ public:
     };
 };
 
-class IntValue : public StoreValue {
+class NumberValueType {
+public:
+    virtual void incr() = 0;
+    virtual void decr() = 0;
+};
+
+using NumberValueTypeSP = std::shared_ptr<NumberValueType>;
+
+class IntValue : public StoreValue, public NumberValueType {
 public:
     IntValue(int i)
         : value_(i) {};
@@ -49,14 +57,14 @@ public:
     std::size_t size() const override { return sizeof(value_); }
     std::string string() const override { return "int: " + std::to_string(value_); }
 
-    void incr() { value_ += 1; }
-    void decr() { value_ -= 1; }
+    void incr() override { value_ += 1; }
+    void decr() override { value_ -= 1; }
 
 private:
     int value_;
 };
 
-class FloatValue : public StoreValue {
+class FloatValue : public StoreValue, public NumberValueType {
 public:
     FloatValue(float f)
         : value_(f) {};
@@ -70,8 +78,8 @@ public:
     std::size_t size() const override { return sizeof(value_); }
     std::string string() const override { return "float: " + std::to_string(value_); }
 
-    void incr() { value_ += 1; }
-    void decr() { value_ -= 1; }
+    void incr() override { value_ += 1; }
+    void decr() override { value_ -= 1; }
 
 private:
     float value_;

--- a/include/store_value.h
+++ b/include/store_value.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "util.h"
+
 #include <memory>
 #include <stdexcept>
 #include <string>

--- a/include/store_value.h
+++ b/include/store_value.h
@@ -45,7 +45,7 @@ public:
     std::vector<uint8_t> serialize() const override;
     void deserialize(std::ifstream &) override;
 
-    ValueType getValueType() { return ValueType::INT; }
+    ValueType getValueType() const override { return ValueType::INT; }
     std::size_t size() const override { return sizeof(value_); }
     std::string string() const override { return "int: " + std::to_string(value_); }
 
@@ -66,7 +66,7 @@ public:
     std::vector<uint8_t> serialize() const override;
     void deserialize(std::ifstream &) override;
 
-    ValueType getValueType() { return ValueType::FLOAT; }
+    ValueType getValueType() const override { return ValueType::FLOAT; }
     std::size_t size() const override { return sizeof(value_); }
     std::string string() const override { return "float: " + std::to_string(value_); }
 
@@ -87,7 +87,7 @@ public:
     std::vector<uint8_t> serialize() const override;
     void deserialize(std::ifstream &) override;
 
-    ValueType getValueType() { return ValueType::STRING; }
+    ValueType getValueType() const override { return ValueType::STRING; }
     std::size_t size() const override { return sizeof(value_); }
     std::string string() const override { return "str: " + value_; }
 
@@ -105,7 +105,7 @@ public:
     std::vector<uint8_t> serialize() const override;
     void deserialize(std::ifstream &) override;
 
-    ValueType getValueType() { return ValueType::IDENTIIFER; }
+    ValueType getValueType() const override { return ValueType::IDENTIIFER; }
     std::size_t size() const override { return sizeof(value_); }
     std::string string() const override { return "id:" + value_; }
 
@@ -127,7 +127,7 @@ public:
     std::vector<uint8_t> serialize() const override;
     void deserialize(std::ifstream &) override;
 
-    ValueType getValueType() { return ValueType::LIST; }
+    ValueType getValueType() const override { return ValueType::LIST; }
     std::size_t size() const override;
     std::string string() const override;
 

--- a/include/syntax_tree.h
+++ b/include/syntax_tree.h
@@ -163,4 +163,9 @@ private:
     std::vector<ValueASTNodeSP> args_;
 };
 
-using CommandNodeSP = std::shared_ptr<CommandASTNode>;
+using CommandASTNodeSP = std::shared_ptr<CommandASTNode>;
+using IntASTNodeSP = std::shared_ptr<IntASTNode>;
+using FloatASTNodeSP = std::shared_ptr<FloatASTNode>;
+using StringASTNodeSP = std::shared_ptr<StringASTNode>;
+using IdentifierASTNodeSP = std::shared_ptr<IdentifierASTNode>;
+using ListASTNodeSP = std::shared_ptr<ListASTNode>;

--- a/include/syntax_tree.h
+++ b/include/syntax_tree.h
@@ -143,24 +143,24 @@ class CommandASTNode : public ASTNode {
 public:
     CommandASTNode()
         : cmdType_(CommandType::UNKNOWN)
-        , args_(std::vector<ASTNodeSP>()) {};
+        , args_(std::vector<ValueASTNodeSP>()) {};
     CommandASTNode(const std::string &c)
         : cmdType_(mapGet(mapToCmd, c, CommandType::UNKNOWN))
-        , args_(std::vector<ASTNodeSP>()) {};
+        , args_(std::vector<ValueASTNodeSP>()) {};
     CommandASTNode(CommandType c)
         : cmdType_(c)
-        , args_(std::vector<ASTNodeSP>()) {};
+        , args_(std::vector<ValueASTNodeSP>()) {};
 
     NodeType getNodeType() const { return NodeType::COMMAND; };
     std::string string() const override;
 
     CommandType getCmdType() const { return cmdType_; }
-    void addArg(ASTNodeSP &a) { args_.push_back(a); };
-    std::vector<ASTNodeSP> &getArgs() { return args_; };
+    void addArg(ValueASTNodeSP &a) { args_.push_back(a); };
+    std::vector<ValueASTNodeSP> &getArgs() { return args_; };
 
 private:
     CommandType cmdType_;
-    std::vector<ASTNodeSP> args_;
+    std::vector<ValueASTNodeSP> args_;
 };
 
 using CommandNodeSP = std::shared_ptr<CommandASTNode>;

--- a/include/syntax_tree.h
+++ b/include/syntax_tree.h
@@ -58,32 +58,6 @@ class NilNode : public ASTNode {
     std::string string() { return "{node: nil, value: nil}"; }
 };
 
-class CommandASTNode : public ASTNode {
-public:
-    CommandASTNode()
-        : cmdType_(CommandType::UNKNOWN)
-        , args_(std::vector<ValueASTNodeSP>()) {};
-    CommandASTNode(const std::string &c)
-        : cmdType_(mapGet(mapToCmd, c, CommandType::UNKNOWN))
-        , args_(std::vector<ValueASTNodeSP>()) {};
-    CommandASTNode(CommandType c)
-        : cmdType_(c)
-        , args_(std::vector<ValueASTNodeSP>()) {};
-
-    NodeType getNodeType() const { return NodeType::COMMAND; };
-    std::string string() const override;
-
-    CommandType getCmdType() const { return cmdType_; }
-    void addArg(ValueASTNodeSP &a) { args_.push_back(a); };
-    std::vector<ValueASTNodeSP> &getArgs() { return args_; };
-
-private:
-    CommandType cmdType_;
-    std::vector<ValueASTNodeSP> args_;
-};
-
-using CommandNodeSP = std::shared_ptr<CommandASTNode>;
-
 class ValueASTNode : public ASTNode {
 public:
     virtual StoreValueSP evaluate() const = 0;
@@ -157,3 +131,29 @@ public:
 private:
     std::vector<ValueASTNodeSP> value_;
 };
+
+class CommandASTNode : public ASTNode {
+public:
+    CommandASTNode()
+        : cmdType_(CommandType::UNKNOWN)
+        , args_(std::vector<ValueASTNodeSP>()) {};
+    CommandASTNode(const std::string &c)
+        : cmdType_(mapGet(mapToCmd, c, CommandType::UNKNOWN))
+        , args_(std::vector<ValueASTNodeSP>()) {};
+    CommandASTNode(CommandType c)
+        : cmdType_(c)
+        , args_(std::vector<ValueASTNodeSP>()) {};
+
+    NodeType getNodeType() const { return NodeType::COMMAND; };
+    std::string string() const override;
+
+    CommandType getCmdType() const { return cmdType_; }
+    void addArg(ValueASTNodeSP &a) { args_.push_back(a); };
+    std::vector<ValueASTNodeSP> &getArgs() { return args_; };
+
+private:
+    CommandType cmdType_;
+    std::vector<ValueASTNodeSP> args_;
+};
+
+using CommandNodeSP = std::shared_ptr<CommandASTNode>;

--- a/include/syntax_tree.h
+++ b/include/syntax_tree.h
@@ -62,24 +62,24 @@ class CommandASTNode : public ASTNode {
 public:
     CommandASTNode()
         : cmdType_(CommandType::UNKNOWN)
-        , args_(std::vector<ValueNodeSP>()) {};
+        , args_(std::vector<ValueASTNodeSP>()) {};
     CommandASTNode(const std::string &c)
         : cmdType_(mapGet(mapToCmd, c, CommandType::UNKNOWN))
-        , args_(std::vector<ValueNodeSP>()) {};
+        , args_(std::vector<ValueASTNodeSP>()) {};
     CommandASTNode(CommandType c)
         : cmdType_(c)
-        , args_(std::vector<ValueNodeSP>()) {};
+        , args_(std::vector<ValueASTNodeSP>()) {};
 
     NodeType getNodeType() const { return NodeType::COMMAND; };
     std::string string() const override;
 
     CommandType getCmdType() const { return cmdType_; }
-    void addArg(ValueNodeSP &a) { args_.push_back(a); };
-    std::vector<ValueNodeSP> &getArgs() { return args_; };
+    void addArg(ValueASTNodeSP &a) { args_.push_back(a); };
+    std::vector<ValueASTNodeSP> &getArgs() { return args_; };
 
 private:
     CommandType cmdType_;
-    std::vector<ValueNodeSP> args_;
+    std::vector<ValueASTNodeSP> args_;
 };
 
 using CommandNodeSP = std::shared_ptr<CommandASTNode>;
@@ -89,7 +89,7 @@ public:
     virtual StoreValueSP evaluate() const = 0;
 };
 
-using ValueNodeSP = std::shared_ptr<ValueASTNode>;
+using ValueASTNodeSP = std::shared_ptr<ValueASTNode>;
 
 class IntASTNode : public ValueASTNode {
 public:
@@ -98,6 +98,7 @@ public:
 
     NodeType getNodeType() const { return NodeType::INT; }
     std::string string() const override;
+    StoreValueSP evaluate() const override;
 
 private:
     int value_;
@@ -110,6 +111,7 @@ public:
 
     NodeType getNodeType() const { return NodeType::FLOAT; }
     std::string string() const override;
+    StoreValueSP evaluate() const override;
 
 private:
     float value_;
@@ -122,6 +124,7 @@ public:
 
     NodeType getNodeType() const { return NodeType::STRING; }
     std::string string() const override;
+    StoreValueSP evaluate() const override;
 
 private:
     std::string value_;
@@ -134,6 +137,7 @@ public:
 
     NodeType getNodeType() const { return NodeType::IDENTIFIER; }
     std::string string() const override;
+    StoreValueSP evaluate() const override;
 
 private:
     std::string value_;
@@ -141,14 +145,15 @@ private:
 
 class ListASTNode : public ValueASTNode {
 public:
-    ListASTNode(std::vector<ValueNodeSP> &l)
+    ListASTNode(std::vector<ValueASTNodeSP> &l)
         : value_(l) {};
 
-    void addElem(ValueNodeSP e) { value_.push_back(std::move(e)); }
+    void addNode(ValueASTNodeSP e) { value_.push_back(std::move(e)); }
 
     NodeType getNodeType() const { return NodeType::LIST; }
     std::string string() const override;
+    StoreValueSP evaluate() const override;
 
 private:
-    std::vector<ValueNodeSP> value_;
+    std::vector<ValueASTNodeSP> value_;
 };

--- a/include/syntax_tree.h
+++ b/include/syntax_tree.h
@@ -10,7 +10,7 @@
 #include <vector>
 
 // clang-format off
-enum class NodeType { COMMAND, NIL, INT, FLOAT, STRING, LIST, IDENTIIFER };
+enum class NodeType { COMMAND, NIL, INT, FLOAT, STRING, LIST, IDENTIFIER };
 
 enum class CommandType {
     SET,        GET,            DELETE,
@@ -58,19 +58,20 @@ class NilNode : public ASTNode {
     std::string string() { return "{node: nil, value: nil}"; }
 };
 
-class CommandNode : public ASTNode {
+class CommandASTNode : public ASTNode {
 public:
-    CommandNode()
+    CommandASTNode()
         : cmdType_(CommandType::UNKNOWN)
         , args_(std::vector<ValueNodeSP>()) {};
-    CommandNode(const std::string &c)
+    CommandASTNode(const std::string &c)
         : cmdType_(mapGet(mapToCmd, c, CommandType::UNKNOWN))
         , args_(std::vector<ValueNodeSP>()) {};
-    CommandNode(CommandType c)
+    CommandASTNode(CommandType c)
         : cmdType_(c)
         , args_(std::vector<ValueNodeSP>()) {};
 
     NodeType getNodeType() const { return NodeType::COMMAND; };
+    std::string string() const override;
 
     CommandType getCmdType() const { return cmdType_; }
     void addArg(ValueNodeSP &a) { args_.push_back(a); };
@@ -81,7 +82,7 @@ private:
     std::vector<ValueNodeSP> args_;
 };
 
-using CommandNodeSP = std::shared_ptr<CommandNode>;
+using CommandNodeSP = std::shared_ptr<CommandASTNode>;
 
 class ValueASTNode : public ASTNode {
 public:
@@ -96,6 +97,7 @@ public:
         : value_(i) {};
 
     NodeType getNodeType() const { return NodeType::INT; }
+    std::string string() const override;
 
 private:
     int value_;
@@ -107,6 +109,7 @@ public:
         : value_(f) {};
 
     NodeType getNodeType() const { return NodeType::FLOAT; }
+    std::string string() const override;
 
 private:
     float value_;
@@ -118,6 +121,19 @@ public:
         : value_(s) {};
 
     NodeType getNodeType() const { return NodeType::STRING; }
+    std::string string() const override;
+
+private:
+    std::string value_;
+};
+
+class IdentifierASTNode : public ValueASTNode {
+public:
+    IdentifierASTNode(std::string s)
+        : value_(s) {};
+
+    NodeType getNodeType() const { return NodeType::IDENTIFIER; }
+    std::string string() const override;
 
 private:
     std::string value_;
@@ -129,6 +145,9 @@ public:
         : value_(l) {};
 
     void addElem(ValueNodeSP e) { value_.push_back(std::move(e)); }
+
+    NodeType getNodeType() const { return NodeType::LIST; }
+    std::string string() const override;
 
 private:
     std::vector<ValueNodeSP> value_;

--- a/include/syntax_tree.h
+++ b/include/syntax_tree.h
@@ -106,23 +106,20 @@ public:
     std::string string() const override;
     StoreValueSP evaluate() const override;
 
-private:
+protected:
     std::string value_;
 };
 
-class IdentifierASTNode : public ValueASTNode {
+class IdentifierASTNode : public StringASTNode {
 public:
     IdentifierASTNode()
-        : value_("") {};
+        : StringASTNode() {};
     IdentifierASTNode(std::string s)
-        : value_(s) {};
+        : StringASTNode(s) {};
 
     NodeType getNodeType() const { return NodeType::IDENTIFIER; }
     std::string string() const override;
     StoreValueSP evaluate() const override;
-
-private:
-    std::string value_;
 };
 
 class ListASTNode : public ValueASTNode {

--- a/include/syntax_tree.h
+++ b/include/syntax_tree.h
@@ -67,6 +67,8 @@ using ValueASTNodeSP = std::shared_ptr<ValueASTNode>;
 
 class IntASTNode : public ValueASTNode {
 public:
+    IntASTNode()
+        : value_(0) {};
     IntASTNode(int i)
         : value_(i) {};
 
@@ -80,6 +82,8 @@ private:
 
 class FloatASTNode : public ValueASTNode {
 public:
+    FloatASTNode()
+        : value_(0) {};
     FloatASTNode(float f)
         : value_(f) {};
 
@@ -93,6 +97,8 @@ private:
 
 class StringASTNode : public ValueASTNode {
 public:
+    StringASTNode()
+        : value_("") {};
     StringASTNode(std::string s)
         : value_(s) {};
 
@@ -106,6 +112,8 @@ private:
 
 class IdentifierASTNode : public ValueASTNode {
 public:
+    IdentifierASTNode()
+        : value_("") {};
     IdentifierASTNode(std::string s)
         : value_(s) {};
 
@@ -119,6 +127,8 @@ private:
 
 class ListASTNode : public ValueASTNode {
 public:
+    ListASTNode()
+        : value_(std::vector<ValueASTNodeSP>()) {};
     ListASTNode(std::vector<ValueASTNodeSP> &l)
         : value_(l) {};
 
@@ -136,24 +146,24 @@ class CommandASTNode : public ASTNode {
 public:
     CommandASTNode()
         : cmdType_(CommandType::UNKNOWN)
-        , args_(std::vector<ValueASTNodeSP>()) {};
+        , args_(std::vector<ASTNodeSP>()) {};
     CommandASTNode(const std::string &c)
         : cmdType_(mapGet(mapToCmd, c, CommandType::UNKNOWN))
-        , args_(std::vector<ValueASTNodeSP>()) {};
+        , args_(std::vector<ASTNodeSP>()) {};
     CommandASTNode(CommandType c)
         : cmdType_(c)
-        , args_(std::vector<ValueASTNodeSP>()) {};
+        , args_(std::vector<ASTNodeSP>()) {};
 
     NodeType getNodeType() const { return NodeType::COMMAND; };
     std::string string() const override;
 
     CommandType getCmdType() const { return cmdType_; }
-    void addArg(ValueASTNodeSP &a) { args_.push_back(a); };
-    std::vector<ValueASTNodeSP> &getArgs() { return args_; };
+    void addArg(ASTNodeSP &a) { args_.push_back(a); };
+    std::vector<ASTNodeSP> &getArgs() { return args_; };
 
 private:
     CommandType cmdType_;
-    std::vector<ValueASTNodeSP> args_;
+    std::vector<ASTNodeSP> args_;
 };
 
 using CommandNodeSP = std::shared_ptr<CommandASTNode>;

--- a/include/util.h
+++ b/include/util.h
@@ -29,10 +29,3 @@ inline bool strContains(const std::string &s, const char &c) {
 
 // Removes quotation marks without affecting original string
 std::string removeQuotations(const std::string &s);
-
-// Provides common functionality to be used for string operations.
-class StringHandler {
-public:
-    static void serializeToBuffer(std::vector<uint8_t> &, const std::string &s);
-    static std::string deserializeFromFile(std::ifstream &);
-};

--- a/include/util.h
+++ b/include/util.h
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 static const std::string FILE_HEADER = "KEPLERKV-SAVE|";
 static const int FILE_HEADER_SIZE = (int) FILE_HEADER.size();
@@ -28,3 +29,10 @@ inline bool strContains(const std::string &s, const char &c) {
 
 // Removes quotation marks without affecting original string
 std::string removeQuotations(const std::string &s);
+
+// Provides common functionality to be used for string operations.
+class StringHandler {
+public:
+    static void serializeToBuffer(std::vector<uint8_t> &, const std::string &s);
+    static std::string deserializeFromFile(std::ifstream &);
+};

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -136,9 +136,7 @@ void Handler::handleSet_(std::vector<ValueASTNodeSP> &args, const std::size_t nu
 
         if (!(i + 1 < numArgs) || !args[i + 1]) throw RuntimeErr(VAL_AFTER_IDENT);
 
-        StoreValueSP valueNode = (args[i + 1])->evaluate();
-
-        store_.set(ident, valueNode);
+        store_.set(ident, (args[i + 1])->evaluate());
         std::cout << T_BGREEN << "OK" << T_RESET << std::endl;
     }
 }
@@ -265,7 +263,7 @@ void Handler::handleRename_(std::vector<ValueASTNodeSP> &args, const std::size_t
                       << "\n> ";
             std::string confirm;
             std::getline(std::cin, confirm);
-            if (0 < confirm.size() && (confirm[0]) != 'y') {
+            if (confirm.size() && (confirm[0]) != 'y') {
                 std::cout << T_BYLLW << "No changes made to the store." << T_RESET << std::endl;
                 return;
             }
@@ -292,7 +290,7 @@ void Handler::handleIncr_(std::vector<ValueASTNodeSP> &args, const std::size_t n
             continue;
         }
 
-        NumberValueTypeSP number = std::dynamic_pointer_cast<NumberValueType>(value);
+        NumericTypeSP number = std::dynamic_pointer_cast<NumericType>(value);
         if (!number) {
             std::cout << T_BRED << NOT_NUMERIC << T_RESET << std::endl;
             continue;
@@ -319,7 +317,7 @@ void Handler::handleDecr_(std::vector<ValueASTNodeSP> &args, const std::size_t n
             continue;
         }
 
-        NumberValueTypeSP number = std::dynamic_pointer_cast<NumberValueType>(value);
+        NumericTypeSP number = std::dynamic_pointer_cast<NumericType>(value);
         if (!number) {
             std::cout << T_BRED << NOT_NUMERIC << T_RESET << std::endl;
             continue;

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -294,10 +294,14 @@ void Handler::handleIncr_(std::vector<ValueASTNodeSP> &args, const std::size_t n
             continue;
         }
 
-        if (value->incr())
-            std::cout << T_BGREEN << "OK" << T_RESET << std::endl;
-        else
+        NumberValueTypeSP number = std::dynamic_pointer_cast<NumberValueType>(value);
+        if (!number) {
             std::cout << T_BRED << NOT_NUMERIC << T_RESET << std::endl;
+            continue;
+        }
+
+        number->incr();
+        std::cout << T_BGREEN << "OK" << T_RESET << std::endl;
     }
 }
 
@@ -317,10 +321,14 @@ void Handler::handleDecr_(std::vector<ValueASTNodeSP> &args, const std::size_t n
             continue;
         }
 
-        if (value->decr())
-            std::cout << T_BGREEN << "OK" << T_RESET << std::endl;
-        else
+        NumberValueTypeSP number = std::dynamic_pointer_cast<NumberValueType>(value);
+        if (!number) {
             std::cout << T_BRED << NOT_NUMERIC << T_RESET << std::endl;
+            continue;
+        }
+
+        number->decr();
+        std::cout << T_BGREEN << "OK" << T_RESET << std::endl;
     }
 }
 

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -34,7 +34,7 @@ bool Handler::handleQuery(std::string &query) {
         if (DEBUG) std::cout << "\t" << *n << std::endl;
 
         // https://stackoverflow.com/a/14545746
-        CommandNodeSP cmd = std::dynamic_pointer_cast<CommandASTNode>(n);
+        CommandASTNodeSP cmd = std::dynamic_pointer_cast<CommandASTNode>(n);
         if (cmd == nullptr) throw RuntimeErr(WRONG_CMD_FMT);
 
         // Retrieve appropriate function pointer and run
@@ -130,15 +130,15 @@ void Handler::handleSet_(std::vector<ValueASTNodeSP> &args, const std::size_t nu
     for (std::size_t i = 0; i < numArgs; i += 2) {
         if (!args[i]) continue;
 
-        ValueASTNodeSP identNode = args[i];
-        if (identNode->getNodeType() != NodeType::IDENTIFIER) throw RuntimeErr(NOT_IDENT);
-        const std::string &ident = identNode->value->getString();
+        IdentifierValueSP identNode = std::dynamic_pointer_cast<IdentifierValue>((args[i])->evaluate());
+        if (!identNode) throw RuntimeErr(NOT_IDENT);
+        const std::string &ident = identNode->getValue();
 
         if (!(i + 1 < numArgs) || !args[i + 1]) throw RuntimeErr(VAL_AFTER_IDENT);
 
-        ValueASTNodeSP valueNode = args[i + 1];
+        StoreValueSP valueNode = (args[i + 1])->evaluate();
 
-        store_.set(ident, valueNode->value);
+        store_.set(ident, valueNode);
         std::cout << T_BGREEN << "OK" << T_RESET << std::endl;
     }
 }
@@ -149,9 +149,9 @@ void Handler::handleGet_(std::vector<ValueASTNodeSP> &args, const std::size_t nu
     for (std::size_t i = 0; i < numArgs; i++) {
         if (!args[i]) continue;
 
-        ValueASTNodeSP identNode = args[i];
-        if (identNode->getNodeType() != NodeType::IDENTIFIER) throw RuntimeErr(NOT_IDENT);
-        const std::string &ident = identNode->value->getString();
+        IdentifierValueSP identNode = std::dynamic_pointer_cast<IdentifierValue>(args[i]->evaluate());
+        if (!identNode) throw RuntimeErr(NOT_IDENT);
+        const std::string &ident = identNode->getValue();
 
         StoreValueSP value = store_.get(ident);
         if (value)
@@ -167,9 +167,9 @@ void Handler::handleDelete_(std::vector<ValueASTNodeSP> &args, const std::size_t
     for (std::size_t i = 0; i < numArgs; i++) {
         if (!args[i]) continue;
 
-        ValueASTNodeSP identNode = args[i];
-        if (identNode->getNodeType() != NodeType::IDENTIFIER) throw RuntimeErr(NOT_IDENT);
-        const std::string &ident = identNode->value->getString();
+        IdentifierValueSP identNode = std::dynamic_pointer_cast<IdentifierValue>(args[i]->evaluate());
+        if (!identNode) throw RuntimeErr(NOT_IDENT);
+        const std::string &ident = identNode->getValue();
 
         bool deleted = store_.del(ident);
         if (deleted)
@@ -185,9 +185,9 @@ void Handler::handleUpdate_(std::vector<ValueASTNodeSP> &args, const std::size_t
     for (std::size_t i = 0; i < numArgs; i += 2) {
         if (!args[i]) continue;
 
-        ValueASTNodeSP identNode = args[i];
-        if (identNode->getNodeType() != NodeType::IDENTIFIER) throw RuntimeErr(NOT_IDENT);
-        const std::string &ident = identNode->value->getString();
+        IdentifierValueSP identNode = std::dynamic_pointer_cast<IdentifierValue>(args[i]->evaluate());
+        if (!identNode) throw RuntimeErr(NOT_IDENT);
+        const std::string &ident = identNode->getValue();
 
         if (!(i + 1 < numArgs) || !args[i + 1]) throw RuntimeErr(VAL_AFTER_IDENT);
 
@@ -207,9 +207,9 @@ void Handler::handleResolve_(std::vector<ValueASTNodeSP> &args, const std::size_
     for (std::size_t i = 0; i < numArgs; i++) {
         if (!args[i]) continue;
 
-        ValueASTNodeSP identNode = args[i];
-        if (identNode->getNodeType() != NodeType::IDENTIFIER) throw RuntimeErr(NOT_IDENT);
-        const std::string &ident = identNode->value->getString();
+        IdentifierValueSP identNode = std::dynamic_pointer_cast<IdentifierValue>(args[i]->evaluate());
+        if (!identNode) throw RuntimeErr(NOT_IDENT);
+        const std::string &ident = identNode->getValue();
 
         StoreValueSP value = store_.resolve(ident, true);
         if (value)
@@ -284,9 +284,9 @@ void Handler::handleIncr_(std::vector<ValueASTNodeSP> &args, const std::size_t n
     for (std::size_t i = 0; i < numArgs; i++) {
         if (!args[i]) continue;
 
-        ValueASTNodeSP identNode = args[i];
-        if (identNode->getNodeType() != NodeType::IDENTIFIER) throw RuntimeErr(NOT_IDENT);
-        const std::string &ident = identNode->value->getString();
+        IdentifierValueSP identNode = std::dynamic_pointer_cast<IdentifierValue>(args[i]->evaluate());
+        if (!identNode) throw RuntimeErr(NOT_IDENT);
+        const std::string &ident = identNode->getValue();
 
         StoreValueSP value = store_.resolve(ident);
         if (value == nullptr) {
@@ -307,9 +307,9 @@ void Handler::handleDecr_(std::vector<ValueASTNodeSP> &args, const std::size_t n
     for (std::size_t i = 0; i < numArgs; i++) {
         if (!args[i]) continue;
 
-        ValueASTNodeSP identNode = args[i];
-        if (identNode->getNodeType() != NodeType::IDENTIFIER) throw RuntimeErr(NOT_IDENT);
-        const std::string &ident = identNode->value->getString();
+        IdentifierValueSP identNode = std::dynamic_pointer_cast<IdentifierValue>(args[i]->evaluate());
+        if (!identNode) throw RuntimeErr(NOT_IDENT);
+        const std::string &ident = identNode->getValue();
 
         StoreValueSP value = store_.resolve(ident);
         if (value == nullptr) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -55,14 +55,23 @@ ValueASTNodeSP Parser::parseValue_(TokenSP &t) {
     std::string &tValue = t->value;
     switch (t->type) {
         case TokenType::NUMBER:
-            if (strContains(tValue, '.'))
-                return std::make_shared<FloatASTNode>(std::stof(tValue));
-            else
-                return std::make_shared<IntASTNode>(std::stoi(tValue));
+            if (strContains(tValue, '.')) {
+                try {
+                    return std::make_shared<FloatASTNode>(std::stof(tValue));
+                } catch (Exception &e) {
+                    throw RuntimeErr(WRONG_F_FMT);
+                }
+            } else {
+                try {
+                    return std::make_shared<IntASTNode>(std::stoi(tValue));
+                } catch (Exception &e) {
+                    throw RuntimeErr(WRONG_I_FMT);
+                }
+            }
         case TokenType::IDENTIIFER: return std::make_shared<IdentifierASTNode>(tValue);
         case TokenType::STRING: return std::make_shared<StringASTNode>(tValue);
         case TokenType::LIST_START: tt_++; return parseList_();
-        default: break;
+        default: throw UNKNOWN_TOKEN(t->value); break;
     }
     return nullptr;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -40,7 +40,7 @@ CommandASTNodeSP Parser::parseCommand_(TokenSP &cmdTok) {
             case TokenType::COMMAND: throw RuntimeErr(NESTED_CMD);
             case TokenType::UNKNOWN: throw UNKNOWN_TOKEN(t->value);
             default:
-                ASTNodeSP val = parseValue_(t);
+                ValueASTNodeSP val = parseValue_(t);
                 if (val != nullptr) cmd->addArg(val);
 
                 // Wary of where parseValue() ended up

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -25,12 +25,12 @@ std::vector<ASTNodeSP> &Parser::parse(std::vector<TokenSP> &tokens) {
     return nodes;
 }
 
-CommandNodeSP Parser::parseCommand_(TokenSP &cmdTok) {
+CommandASTNodeSP Parser::parseCommand_(TokenSP &cmdTok) {
     CommandType cmdType = mapGet(mapToCmd, cmdTok->value, CommandType::UNKNOWN);
     if (cmdType == CommandType::UNKNOWN) throw INVALID_CMD(cmdTok->value);
     tt_++;
 
-    CommandNodeSP cmd = std::make_shared<CommandASTNode>(cmdType);
+    CommandASTNodeSP cmd = std::make_shared<CommandASTNode>(cmdType);
     while (tt_ != tend_ && (*tt_)->type != TokenType::END) {
         TokenSP &t = *tt_;
         switch (t->type) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,7 +1,6 @@
 #include "parser.h"
 
 #include "error_msgs.h"
-#include "syntax_tree.h"
 #include "util.h"
 
 std::vector<ASTNodeSP> &Parser::parse(std::vector<TokenSP> &tokens) {
@@ -26,12 +25,12 @@ std::vector<ASTNodeSP> &Parser::parse(std::vector<TokenSP> &tokens) {
     return nodes;
 }
 
-ASTNodeSP Parser::parseCommand_(TokenSP &cmdTok) {
+CommandNodeSP Parser::parseCommand_(TokenSP &cmdTok) {
     CommandType cmdType = mapGet(mapToCmd, cmdTok->value, CommandType::UNKNOWN);
     if (cmdType == CommandType::UNKNOWN) throw INVALID_CMD(cmdTok->value);
     tt_++;
 
-    CommandNodeSP cmd = std::make_shared<CommandNode>(cmdType);
+    CommandNodeSP cmd = std::make_shared<CommandASTNode>(cmdType);
     while (tt_ != tend_ && (*tt_)->type != TokenType::END) {
         TokenSP &t = *tt_;
         switch (t->type) {
@@ -41,12 +40,8 @@ ASTNodeSP Parser::parseCommand_(TokenSP &cmdTok) {
             case TokenType::COMMAND: throw RuntimeErr(NESTED_CMD);
             case TokenType::UNKNOWN: throw UNKNOWN_TOKEN(t->value);
             default:
-                StoreValueSP val = parseValue_(t);
-                if (val != nullptr) {
-                    ValueNodeSP a = std::make_shared<ValueNode>(val);
-                    if (t->type == TokenType::IDENTIIFER) a->setAsIdentifier();
-                    cmd->addArg(a);
-                }
+                ASTNodeSP val = parseValue_(t);
+                if (val != nullptr) cmd->addArg(val);
 
                 // Wary of where parseValue() ended up
                 if (tt_ != tend_) tt_++;
@@ -56,24 +51,24 @@ ASTNodeSP Parser::parseCommand_(TokenSP &cmdTok) {
     return cmd;
 }
 
-StoreValueSP Parser::parseValue_(TokenSP &t) {
+ValueASTNodeSP Parser::parseValue_(TokenSP &t) {
     std::string &tValue = t->value;
     switch (t->type) {
         case TokenType::NUMBER:
             if (strContains(tValue, '.'))
-                return std::make_shared<StoreValue>(std::stof(tValue));
+                return std::make_shared<FloatASTNode>(std::stof(tValue));
             else
-                return std::make_shared<StoreValue>(std::stoi(tValue));
-        case TokenType::IDENTIIFER: return std::make_shared<StoreValue>(tValue, true);
-        case TokenType::STRING: return std::make_shared<StoreValue>(tValue);
+                return std::make_shared<IntASTNode>(std::stoi(tValue));
+        case TokenType::IDENTIIFER: return std::make_shared<IdentifierASTNode>(tValue);
+        case TokenType::STRING: return std::make_shared<StringASTNode>(tValue);
         case TokenType::LIST_START: tt_++; return parseList_();
         default: break;
     }
     return nullptr;
 }
 
-StoreValueSP Parser::parseList_() {
-    std::vector<StoreValueSP> lst = std::vector<StoreValueSP>();
+ValueASTNodeSP Parser::parseList_() {
+    std::shared_ptr<ListASTNode> lstNode = std::make_shared<ListASTNode>();
 
     while (tt_ != tend_ && (*tt_)->type != TokenType::END && (*tt_)->type != TokenType::LIST_END) {
         TokenSP &t = *tt_;
@@ -84,12 +79,12 @@ StoreValueSP Parser::parseList_() {
             case TokenType::COMMAND: throw RuntimeErr(CMD_IN_LIST);
             case TokenType::UNKNOWN: throw UNKNOWN_TOKEN(t->value);
             default:
-                StoreValueSP val = parseValue_(t);
-                if (val != nullptr) lst.push_back(val);
+                ValueASTNodeSP val = parseValue_(t);
+                if (val != nullptr) lstNode->addNode(val);
 
                 if (tt_ != tend_) tt_++;
                 break;
         }
     }
-    return std::make_shared<StoreValue>(lst);
+    return lstNode;
 }

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -65,11 +65,11 @@ StoreValueSP Store::resolveRecur_(
                 // Each element should inherit parent history
                 std::unordered_set<std::string> newSeen = std::unordered_set<std::string>(seen);
 
-                IdentifierValueSP idNode = std::dynamic_pointer_cast<IdentifierValue>(found);
+                IdentifierValueSP idNode = std::dynamic_pointer_cast<IdentifierValue>(resolvedL[i]);
                 resolvedL[i] = resolveRecur_(idNode->getValue(), newSeen, resolveIdentsInList);
             }
         }
-        return std::make_shared<StoreValue>(resolvedL);
+        return std::make_shared<ListValue>(resolvedL);
     }
 
     return found;
@@ -143,8 +143,7 @@ void Store::loadFromFile(const std::string &filename) {
         fp.read(&key[0], keySize);
         fp.MV_FP_FORWARD;
 
-        StoreValueSP val = StoreValue::fromFile(fp);
-        map_[key] = val;
+        map_[key] = StoreValue::fromFile(fp);
     }
     fp.close();
 }

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -137,7 +137,7 @@ void Store::loadFromFile(const std::string &filename) {
         fp.read(&key[0], keySize);
         fp.MV_FP_FORWARD;
 
-        StoreValueSP val = std::make_shared<StoreValue>(StoreValue::fromFile(fp));
+        StoreValueSP val = StoreValue::fromFile(fp);
         map_[key] = val;
     }
     fp.close();

--- a/src/store_value.cpp
+++ b/src/store_value.cpp
@@ -42,18 +42,16 @@ std::vector<uint8_t> StringValue::serialize() const {
     const uint8_t *size_ptr = reinterpret_cast<const uint8_t *>(&strSize);
     buf.insert(buf.end(), size_ptr, size_ptr + sizeof(strSize));
 
-    const uint8_t *val_ptr = reinterpret_cast<const uint8_t *>(&value_);
-    buf.insert(buf.end(), val_ptr, val_ptr + strSize);
+    buf.insert(buf.end(), value_.begin(), value_.end());
     return buf;
 }
 
 void StringValue::deserialize(std::ifstream &fp) {
     size_t strSize;
     fp.read(reinterpret_cast<char *>(&strSize), sizeof(strSize));
-    std::string sval(strSize, '\0');
 
-    fp.read(&sval[0], strSize);
-    value_ = sval;
+    value_ = std::string(strSize, '\0');
+    fp.read(&value_[0], strSize);
 }
 
 // Identifiers are serialized as [si][size][string]

--- a/src/store_value.cpp
+++ b/src/store_value.cpp
@@ -37,22 +37,31 @@ std::vector<uint8_t> StringValue::serialize() const {
     std::vector<uint8_t> buf;
     buf.push_back('s');
     buf.push_back('s');
-    serializeToBuffer(buf, value_);
+
+    const size_t &strSize = value_.size();
+    const uint8_t *size_ptr = reinterpret_cast<const uint8_t *>(&strSize);
+    buf.insert(buf.end(), size_ptr, size_ptr + sizeof(strSize));
+
+    const uint8_t *val_ptr = reinterpret_cast<const uint8_t *>(&value_);
+    buf.insert(buf.end(), val_ptr, val_ptr + strSize);
     return buf;
 }
 
-void StringValue::deserialize(std::ifstream &fp) { value_ = deserializeFromFile(fp); }
+void StringValue::deserialize(std::ifstream &fp) {
+    size_t strSize;
+    fp.read(reinterpret_cast<char *>(&strSize), sizeof(strSize));
+    std::string sval(strSize, '\0');
+
+    fp.read(&sval[0], strSize);
+    value_ = sval;
+}
 
 // Identifiers are serialized as [si][size][string]
 std::vector<uint8_t> IdentifierValue::serialize() const {
-    std::vector<uint8_t> buf;
-    buf.push_back('s');
-    buf.push_back('i');
-    serializeToBuffer(buf, value_);
+    std::vector<uint8_t> buf = StringValue::serialize();
+    buf[1] = 'i';
     return buf;
 }
-
-void IdentifierValue::deserialize(std::ifstream &fp) { value_ = deserializeFromFile(fp); }
 
 // Lists are serialized as [l][num elements][e1|e2|...|en|]
 std::vector<uint8_t> ListValue::serialize() const {

--- a/src/store_value.cpp
+++ b/src/store_value.cpp
@@ -85,7 +85,7 @@ void ListValue::deserialize(std::ifstream &fp) {
 
     std::vector<StoreValueSP> lst = std::vector<StoreValueSP>();
     for (size_t i = 0; i < numVals; i++) {
-        StoreValueSP valsp = std::make_shared<StoreValue>(fromFile(fp));
+        StoreValueSP valsp = fromFile(fp);
         lst.push_back(valsp);
     }
     value_ = lst;

--- a/src/syntax_tree.cpp
+++ b/src/syntax_tree.cpp
@@ -1,55 +1,42 @@
 #include "syntax_tree.h"
 
-ValueNode::ValueNode(StoreValueSP s)
-    : value(s) {
-    if (s->isInt())
-        valType_ = ValueType::INT;
-    else if (s->isFloat())
-        valType_ = ValueType::FLOAT;
-    else if (s->isString())
-        valType_ = ValueType::STRING;
-    else if (s->isList())
-        valType_ = ValueType::LIST;
-}
-
-std::string ValueNode::string() const {
-    std::string s = "{node: Value";
-    switch (valType_) {
-        case ValueType::INT:
-            s += ", type: Integer, value: " + std::to_string(value->getInt()) + "}";
-            break;
-        case ValueType::FLOAT:
-            s += ", type: Float, value: " + std::to_string(value->getFloat()) + "}";
-            break;
-        case ValueType::STRING: s += ", type: String, value: " + value->getString() + "}"; break;
-        case ValueType::IDENTIFIER:
-            s += ", type: Identifier, value: " + value->getString() + "}";
-            break;
-        case ValueType::LIST:
-            s += ", type: List, value: [";
-
-            const std::vector<StoreValueSP> &values = value->getList();
-            for (const auto &v : values) {
-                if (!v) continue;
-                s += v->string() + ", ";
-            }
-            if (!values.empty()) {
-                s.pop_back();
-                s.pop_back();
-            }
-            s += "]}";
-            break;
-    }
-    return s;
-}
-
-std::string CommandNode::string() const {
+std::string CommandASTNode::string() const {
     std::string s = "{node: Command, cmd: " + std::to_string((int) cmdType_) + ", args: [";
     for (const auto &a : args_) {
         if (!a) continue;
         s += a->string() + ", ";
     }
     if (!args_.empty()) {
+        s.pop_back();
+        s.pop_back();
+    }
+    s += "]}";
+    return s;
+}
+
+std::string IntASTNode::string() const {
+    return "{node: Value, type: Int, value: " + std::to_string(value_) + "}";
+}
+
+std::string FloatASTNode::string() const {
+    return "{node: Value, type: Float, value: " + std::to_string(value_) + "}";
+}
+
+std::string StringASTNode::string() const {
+    return "{node: Value, type: String, value: " + value_ + "}";
+}
+
+std::string IdentifierASTNode::string() const {
+    return "{node: Value, type: Identifier, value: " + value_ + "}";
+}
+
+std::string ListASTNode::string() const {
+    std::string s = "{node: Value, type: String, value: [";
+    for (const auto &v : value_) {
+        if (!v) continue;
+        s += v->string() + ", ";
+    }
+    if (!value_.empty()) {
         s.pop_back();
         s.pop_back();
     }

--- a/src/syntax_tree.cpp
+++ b/src/syntax_tree.cpp
@@ -18,16 +18,26 @@ std::string IntASTNode::string() const {
     return "{node: Value, type: Int, value: " + std::to_string(value_) + "}";
 }
 
+StoreValueSP IntASTNode::evaluate() const { return std::make_shared<IntValue>(value_); }
+
 std::string FloatASTNode::string() const {
     return "{node: Value, type: Float, value: " + std::to_string(value_) + "}";
 }
+
+StoreValueSP FloatASTNode::evaluate() const { return std::make_shared<FloatValue>(value_); }
 
 std::string StringASTNode::string() const {
     return "{node: Value, type: String, value: " + value_ + "}";
 }
 
+StoreValueSP StringASTNode::evaluate() const { return std::make_shared<StringValue>(value_); }
+
 std::string IdentifierASTNode::string() const {
     return "{node: Value, type: Identifier, value: " + value_ + "}";
+}
+
+StoreValueSP IdentifierASTNode::evaluate() const {
+    return std::make_shared<IdentifierValue>(value_);
 }
 
 std::string ListASTNode::string() const {
@@ -42,4 +52,11 @@ std::string ListASTNode::string() const {
     }
     s += "]}";
     return s;
+}
+
+StoreValueSP ListASTNode::evaluate() const {
+    std::shared_ptr<ListValue> listVal = std::make_shared<ListValue>();
+    for (const auto &node : value_)
+        listVal->append(node->evaluate());
+    return listVal;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -12,3 +12,21 @@ std::string removeQuotations(const std::string &s) {
     res.erase(first_quote, 1);
     return res;
 }
+
+void StringHandler::serializeToBuffer(std::vector<uint8_t> &buf, const std::string &s) {
+    const size_t &strSize = s.size();
+    const uint8_t *size_ptr = reinterpret_cast<const uint8_t *>(&strSize);
+    buf.insert(buf.end(), size_ptr, size_ptr + sizeof(strSize));
+
+    const uint8_t *val_ptr = reinterpret_cast<const uint8_t *>(&s);
+    buf.insert(buf.end(), val_ptr, val_ptr + strSize);
+}
+
+std::string StringHandler::deserializeFromFile(std::ifstream &fp) {
+    size_t strSize;
+    fp.read(reinterpret_cast<char *>(&strSize), sizeof(strSize));
+    std::string sval(strSize, '\0');
+
+    fp.read(&sval[0], strSize);
+    return sval;
+}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -12,21 +12,3 @@ std::string removeQuotations(const std::string &s) {
     res.erase(first_quote, 1);
     return res;
 }
-
-void StringHandler::serializeToBuffer(std::vector<uint8_t> &buf, const std::string &s) {
-    const size_t &strSize = s.size();
-    const uint8_t *size_ptr = reinterpret_cast<const uint8_t *>(&strSize);
-    buf.insert(buf.end(), size_ptr, size_ptr + sizeof(strSize));
-
-    const uint8_t *val_ptr = reinterpret_cast<const uint8_t *>(&s);
-    buf.insert(buf.end(), val_ptr, val_ptr + strSize);
-}
-
-std::string StringHandler::deserializeFromFile(std::ifstream &fp) {
-    size_t strSize;
-    fp.read(reinterpret_cast<char *>(&strSize), sizeof(strSize));
-    std::string sval(strSize, '\0');
-
-    fp.read(&sval[0], strSize);
-    return sval;
-}


### PR DESCRIPTION
Ditching the `std::variant` pattern for a more common sense and flatter node structure by having explicit types of each node.
* The `Parser` does not directly handle any `StoreValue` anymore, but each `ASTNode` has a `evaluate()` to return back a pointer to a `StoreValue`
* Using `std::dynamic_pointer_cast` to simplify all the type-checking logic from before
* Strings and identifiers are much more unified, with identifiers inheriting nearly all attributes of strings